### PR TITLE
Allow the bundle to be used from the command line

### DIFF
--- a/ImageHandler.php
+++ b/ImageHandler.php
@@ -9,7 +9,7 @@ use Gregwar\ImageBundle\Image;
  *
  * @author Gregwar <g.passault@gmail.com>
  */
-class ImageHandler extends Image 
+class ImageHandler extends Image
 {
     protected $fileCallback = null;
 
@@ -28,7 +28,7 @@ class ImageHandler extends Image
     {
         $callback = $this->fileCallback;
 
-        if (null === $callback)
+        if (null === $callback || substr($filename, 0, 1) == '/')
             return $filename;
 
         return $callback($filename);

--- a/Services/ImageHandling.php
+++ b/Services/ImageHandling.php
@@ -53,15 +53,15 @@ class ImageHandling
      */
     private function createInstance($file, $w = null, $h = null)
     {
-        $asset = $this->container->get('templating.helper.assets');
+        $container = $this->container;
 
         $handler_class = $this->handler_class;
         $image = new $handler_class($file, $w, $h);
 
         $image->setCacheDir($this->cache_dir);
 
-        $image->setFileCallback(function($file) use ($asset) {
-            return $asset->getUrl($file);
+        $image->setFileCallback(function($file) use ($container) {
+            return $container->get('templating.helper.assets')->getUrl($file);
         });
 
         return $image;


### PR DESCRIPTION
Moving to further late binding of templating.helper.assets on Image filename callback

This allows this bundle to be used from the commandline for processing images
(if not using templates). Additionally, completely ignores the callback if a
path begins with '/', as all {{ asset }} tag calls (which is where this would
come into play) use relative URLs.

Without this, when invoking a Symfony2 CLI Command using code that depends on this library, an exception gets thrown that the templating.helper.assets service cannot be created due to the lack of the HTTP / Request environment:

  [Symfony\Component\DependencyInjection\Exception\InactiveScopeException]  
  You cannot create a service ("templating.helper.assets") of an inactive scope ("request").
