### PR TITLE
silent warnings

### DIFF
--- a/Image.php
+++ b/Image.php
@@ -876,7 +876,7 @@ class Image
 
         if ($this->file) {
             try {
-                $inputInfos = filectime($this->file);
+                $inputInfos = @filectime($this->file);
             } catch (\Exception $e) {
             }
         } else {


### PR DESCRIPTION
Hi,

I'm getting a lot of such 

PHP Warning: filectime(): stat failed for images/products/2/522834a3a5eed.jpg in /home/travis/build/expcommerce/exp/vendor/gregwar/image-bundle/Gregwar/ImageBundle/Image.php on line 879

warnings while running behat tests. Can we silent this?

Best regards,
Michal
