### PR TITLE
Now we can use this class behind a server proxy/firewall

### DIFF
--- a/Image.php
+++ b/Image.php
@@ -91,6 +91,11 @@ class Image
     protected $height = null;
 
     /**
+     * Stream of a temporary file
+     */
+    protected $tempStreamFile = null;
+
+    /**
      * Supported types
      */
     public static $types = array(
@@ -143,7 +148,7 @@ class Image
 
     public function __construct($originalFile = null, $width = null, $height = null)
     {
-        $this->file = $originalFile;
+        $this->file = $this->loadFile($originalFile);
         $this->width = $width;
         $this->height = $height;
 
@@ -153,6 +158,32 @@ class Image
 
         if ($originalFile !== null) {
             $this->type = $this->guessType();
+        }
+    }
+
+    public function __destruct()
+    {
+        if($this->tempStreamFile) {
+            fclose($this->tempStreamFile);
+        }
+    }
+
+    protected function loadFile($file)
+    {
+        if (realpath($file) !== false) {
+            return $file;
+        } else {
+
+            $tmpfile = file_get_contents($file);
+
+            // Write $tmpfile in a temporary file
+            $this->tempStreamFile = tmpfile();
+            fwrite($this->tempStreamFile, $tmpfile);
+            fseek($this->tempStreamFile, 0);
+
+            $streamMetadData = stream_get_meta_data($this->tempStreamFile);
+
+            return $streamMetadData['uri'];
         }
     }
 
@@ -225,7 +256,7 @@ class Image
      */
     public function fromFile($originalFile)
     {
-        $this->file = $originalFile;
+        $this->file = $this->loadFile($originalFile);
 
         return $this;
     }


### PR DESCRIPTION
My compagny set a firewall/proxy recently.
I've just made some little change because the exif_imagetype doesn't take care about the proxy configuration like the function file_get_content.

With the change, if the file is a remote one (from an url), we download it with  file_get_content an put it in a temporary file.
When php destroy the class, the temporary file is closed.

And for configure the proxy, i've created a listner who made this : 
[php]
$context = array(
                'http' => array(
                    'proxy' => 'tcp://XXX.XXX.XXX.XXX:8058',
                    'request_fulluri' => true,
                )
            );
stream_context_set_default($this->getStreamContext());
[/php]
