### PR TITLE
Add symfony/framework-bundle dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,9 @@
         }
     ],
     "require": {
-        "php": ">=5.3.0",
+        "php": ">=5.3.3",
         "ext-gd": "*",
+        "symfony/framework-bundle": "~2.3",
         "gregwar/image": "2.*"
     },
     "autoload": {


### PR DESCRIPTION
At least `symfony/framework-bundle` dependency should be required as you are publishing a bundle.