### PR TITLE
Update assets helpers call with SF3.0

### DIFF
--- a/Services/ImageHandling.php
+++ b/Services/ImageHandling.php
@@ -134,7 +134,7 @@ class ImageHandling
         $image->setActualCacheDir($webDir.'/'.$this->cacheDirectory);
 
         $image->setFileCallback(function ($file) use ($container) {
-            return $container->get('templating.helper.assets')->getUrl($file);
+            return $container->get('assets.packages')->getUrl($file);
         });
 
         return $image;


### PR DESCRIPTION
Symfony 3.0 has removed the service "templating.helper.assets", we should use assets.packages now.