### PR TITLE
Adjust asset helper name depending on Symfony version

### DIFF
--- a/Services/ImageHandling.php
+++ b/Services/ImageHandling.php
@@ -134,7 +134,11 @@ class ImageHandling
         $image->setActualCacheDir($webDir.'/'.$this->cacheDirectory);
 
         $image->setFileCallback(function ($file) use ($container) {
-            return $container->get('templating.helper.assets')->getUrl($file);
+            if ($container->has('templating.helper.assets')) {
+                return $container->get('templating.helper.assets')->getUrl($file);
+            } else {
+                return $container->get('assets.packages')->getUrl($file);
+            }
         });
 
         return $image;


### PR DESCRIPTION
Since Symfony 3 service templating.helper.assets is replaced with assets.packages

Relates to issue #92