### PR TITLE
catch the \InvalidArgumentException and use config to continue.

### DIFF
--- a/Services/ImageHandling.php
+++ b/Services/ImageHandling.php
@@ -91,8 +91,19 @@ class ImageHandling
     public function open($file)
     {
         if (strlen($file) >= 1 && $file[0] == '@') {
-            $file = $this->fileLocator instanceof FileLocatorInterface
-                ? $this->fileLocator->locate($file) : $this->fileLocator->locateResource($file);
+            try {
+                if ($this->fileLocator instanceof FileLocatorInterface) {
+                    $file = $this->fileLocator->locate($file);
+                } else {
+                    $this->fileLocator->locateResource($file);
+                }
+            } catch (\InvalidArgumentException $exception) {
+                if ($this->throwException || false == $this->fallbackImage) {
+                    throw $exception;
+                }
+
+                $file = $this->fallbackImage;
+            }
         }
 
         return $this->createInstance($file);


### PR DESCRIPTION
The Symfony FileLocator or Kernel (locateFile) might throw an InvalidArgumentException when a file is not found or the path is wrong. I think depending when configuration states no exceptions the exception must be caught and a fallback should be set (if any). 