### PR TITLE
Get gregwar/image from master branch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "ext-gd": "*",
         "symfony/framework-bundle": "^2.3 || ^3.0",
         "twig/twig": "^1.12 || ^2.0",
-        "gregwar/image": "2.*"
+        "gregwar/image": "master"
     },
     "require-dev": {
         "sllh/php-cs-fixer-styleci-bridge": "~1.1"


### PR DESCRIPTION
The latest release of gregwar/image package is not up to date and there are issues that are fixed in the master branch.