### PR TITLE
Fix deprecated `assets.packages` service call over Symfony 3.2

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -12,6 +12,7 @@ services:
           - '%gregwar_image.cache_dir_mode%'
           - '%image.handler.class%'
           - '@service_container'
+          - '@assets.packages'
           - '@file_locator'
           - '%gregwar_image.throw_exception%'
           - '%gregwar_image.fallback_image%'

--- a/Services/ImageHandling.php
+++ b/Services/ImageHandling.php
@@ -5,6 +5,7 @@ namespace Gregwar\ImageBundle\Services;
 use Gregwar\ImageBundle\ImageHandler;
 use Symfony\Component\Config\FileLocatorInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\Asset\Packages;
 use Symfony\Component\HttpKernel\KernelInterface;
 
 /**
@@ -31,6 +32,11 @@ class ImageHandling
     private $container;
 
     /**
+     * @var Packages
+     */
+    private $assetsPackages;
+
+    /**
      * @var string
      */
     private $handlerClass;
@@ -54,7 +60,7 @@ class ImageHandling
      * @param bool                                 $throwException
      * @param string                               $fallbackImage
      */
-    public function __construct($cacheDirectory, $cacheDirMode, $handlerClass, ContainerInterface $container, $fileLocator, $throwException, $fallbackImage)
+    public function __construct($cacheDirectory, $cacheDirMode, $handlerClass, ContainerInterface $container, Packages $assetsPackages, $fileLocator, $throwException, $fallbackImage)
     {
         if (!$fileLocator instanceof FileLocatorInterface && $fileLocator instanceof KernelInterface) {
             throw new \InvalidArgumentException(
@@ -76,6 +82,7 @@ class ImageHandling
         $this->cacheDirMode = intval($cacheDirMode);
         $this->handlerClass = $handlerClass;
         $this->container = $container;
+        $this->assetsPackages = $assetsPackages;
         $this->fileLocator = $fileLocator;
         $this->throwException = $throwException;
         $this->fallbackImage = $fallbackImage;
@@ -150,7 +157,7 @@ class ImageHandling
             });
         } else {
             $image->setFileCallback(function ($file) use ($container) {
-                return $container->get('assets.packages')->getUrl($file);
+                return $this->assetsPackages->getUrl($file);
             });
         }
 


### PR DESCRIPTION
User Deprecated: The "assets.packages" service is private, getting it from the container is deprecated since Symfony 3.2 and will fail in 4.0. You should either make the service public, or stop using the container directly and use dependency injection instead.